### PR TITLE
Some UI and style changes for certificate page and a bug fix

### DIFF
--- a/static/sass/_default.scss
+++ b/static/sass/_default.scss
@@ -422,8 +422,28 @@ header.global .user > :last-child.primary > a:hover{
     background-color: $ms-primary-button-hover !important;
 }
 
+//-------------------------
+// Certificate top shadow and putting into grey area changes
+//-------------------------
 
-//------------------
+.accomplishment-rendering {
+    border-top: 0;
+    top: inherit;
+}
+
+
+.wrapper-accomplishment-rendering {
+    padding: 30px 2.85714%;
+}
+
+.layout-accomplishment .accomplishment-rendering {
+    top: inherit;
+}
+
+.layout-accomplishment .wrapper-introduction {
+    margin-bottom: 0;
+}
+
 // View on the course view page
 //------------------
 div.course-actions > a.enter-course {

--- a/templates/certificates/_about-accomplishments.html
+++ b/templates/certificates/_about-accomplishments.html
@@ -3,7 +3,7 @@
 
     <div class="about-copy copy copy-meta">
         <p>
-	{platform_name} acknowledges achievements through certificates, which are awarded for various activities Microsoft Learning students complete under the <a href="https://openedx.microsoft.com/tos">Microsoft Learning Terms of Service</a>. Some certificates require completing additional steps.
+	${platform_name} acknowledges achievements through certificates, which are awarded for various activities Microsoft Learning students complete under the <a href="https://openedx.microsoft.com/tos">Microsoft Learning Terms of Service</a>. Some certificates require completing additional steps.
 	</p>
     </div>
 </section>


### PR DESCRIPTION
1)  There was a missing $ in front of platform_name place holder. Fixed it.
2) Made some style changes on the certification html page so that upper shadow line is removed and cert is moved into the grey area and some unnecessary margin from top is also removed.

@Microsoft/lex 