### PR TITLE
redirected the help section for contact information link to /faq

### DIFF
--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -142,7 +142,7 @@
       <div class="cta cta-help">
         <h3>{% trans "Need Help?" %}</h3>
         <p>
-          {% blocktrans with start_link='<a href="{{MKTG_URL_FAQ}}">' end_link='</a>' %}
+          {% blocktrans with start_link='<a href="/faq">' end_link='</a>' %}
               View our {{ start_link }}help section for contact information and answers to commonly asked questions{{ end_link }}
           {% endblocktrans %}
         </p>


### PR DESCRIPTION
added the /faq link to help section in password reset conformation page.