### PR TITLE
Customizing CMS error pages and TOS link with comprehensive theming

### DIFF
--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -1,0 +1,30 @@
+<%page expression_filter="h"/>
+<%!
+from django.utils.translation import ugettext as _
+from openedx.core.djangolib.markup import HTML, Text
+%>
+<%inherit file="base.html" />
+<%block name="title">${_("Page Not Found")}</%block>
+<%block name="bodyclass">view-util util-404</%block>
+
+
+<%block name="content">
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">${_("Page not found")}</h1>
+    </header>
+    <article class="content-primary" role="main">
+      <p>
+      ${_('The page that you were looking for was not found.')}
+      ${Text(_('Go back to the {homepage} or let us know about any pages that may have been moved at {email}.')).format(
+        homepage=HTML('<a href="/">homepage</a>'),
+        email=HTML('<a href="mailto:{address}">{address}</a>').format(
+          address=Text(settings.TECH_SUPPORT_EMAIL)
+        )
+      )}
+      </p>
+    </article>
+  </section>
+</div>
+</%block>

--- a/cms/templates/404.html
+++ b/cms/templates/404.html
@@ -17,12 +17,7 @@ from openedx.core.djangolib.markup import HTML, Text
     <article class="content-primary" role="main">
       <p>
       ${_('The page that you were looking for was not found.')}
-      ${Text(_('Go back to the {homepage} or let us know about any pages that may have been moved at {email}.')).format(
-        homepage=HTML('<a href="/">homepage</a>'),
-        email=HTML('<a href="mailto:{address}">{address}</a>').format(
-          address=Text(settings.TECH_SUPPORT_EMAIL)
-        )
-      )}
+ +	  ${_('Go back to the {homepage} or let us know about any pages that may have been moved by contacting support.')}
       </p>
     </article>
   </section>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -1,0 +1,41 @@
+<%page expression_filter="h"/>
+<%!
+from openedx.core.djangolib.markup import HTML, Text
+from django.utils.translation import ugettext as _
+%>
+<%inherit file="base.html" />
+<%block name="title">
+${Text(_("{studio_name} Server Error")).format(
+  studio_name=Text(settings.STUDIO_SHORT_NAME)
+)}
+</%block>
+<%block name="bodyclass">view-util util-500</%block>
+
+<%block name="content">
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">
+        ${Text(_(u"The {em_start}{studio_name}{em_end} servers encountered an error")).format(
+          em_start=HTML('<em>'),
+          em_end=HTML('</em>'),
+          studio_name=Text(settings.STUDIO_SHORT_NAME),
+        )}
+      </h1>
+    </header>
+    <article class="content-primary" role="main">
+      <p>
+        ${Text(_("An error occurred in {studio_name} and the page could not be loaded. Please try again in a few moments.")).format(
+          studio_name=Text(settings.STUDIO_SHORT_NAME),
+        )}
+        ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
+        ${Text(_(u'If the problem persists, please email us at {email_link}.')).format(
+          email_link=HTML(u'<a href="mailto:{email_address}">{email_address}</a>').format(
+            email_address=Text(settings.TECH_SUPPORT_EMAIL),
+          )
+        )}
+      </p>
+    </article>
+  </section>
+</div>
+</%block>

--- a/cms/templates/500.html
+++ b/cms/templates/500.html
@@ -29,11 +29,7 @@ ${Text(_("{studio_name} Server Error")).format(
           studio_name=Text(settings.STUDIO_SHORT_NAME),
         )}
         ${_("We've logged the error and our staff is currently working to resolve this error as soon as possible.")}
-        ${Text(_(u'If the problem persists, please email us at {email_link}.')).format(
-          email_link=HTML(u'<a href="mailto:{email_address}">{email_address}</a>').format(
-            email_address=Text(settings.TECH_SUPPORT_EMAIL),
-          )
-        )}
+        ${_('If the problem persists, please contact support.')}
       </p>
     </article>
   </section>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -1,0 +1,41 @@
+<%page expression_filter="h"/>
+<%inherit file="base.html" />
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+from django.conf import settings
+%>
+<%block name="bodyclass">error</%block>
+<%block name="title">
+  % if error == '404':
+    404 - ${_("Page Not Found")}
+  % elif error == '500':
+    500 - ${_("Internal Server Error")}
+  % endif
+</%block>
+
+<%!
+help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
+help_link_end = '</a>'
+%>
+
+<%block name="content">
+  <article class="error-prompt">
+    % if error == '404':
+      <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
+      <p class="description">${Text(_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
+          studio_name=settings.STUDIO_SHORT_NAME,
+          link_start=HTML(help_link_start),
+          link_end=HTML(help_link_end),
+        )}</p>
+    % elif error == '500':
+      <h1>${_("The Server Encountered an Error")}</h1>
+      <p class="description">${Text(_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
+          studio_name=settings.STUDIO_SHORT_NAME,
+          link_start=HTML(help_link_start),
+          link_end=HTML(help_link_end),
+        )}</p>
+    % endif
+    <a href="/" class="back-button">${_("Back to dashboard")}</a>
+  </article>
+</%block>

--- a/cms/templates/error.html
+++ b/cms/templates/error.html
@@ -14,27 +14,14 @@ from django.conf import settings
   % endif
 </%block>
 
-<%!
-help_link_start = '<a href="mailto:{email}">'.format(email=settings.TECH_SUPPORT_EMAIL)
-help_link_end = '</a>'
-%>
-
 <%block name="content">
   <article class="error-prompt">
     % if error == '404':
       <h1>${_("The Page You Requested Page Cannot be Found")}</h1>
-      <p class="description">${Text(_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
-          studio_name=settings.STUDIO_SHORT_NAME,
-          link_start=HTML(help_link_start),
-          link_end=HTML(help_link_end),
-        )}</p>
+      <p class="description">${_("We're sorry. We couldn't find the {studio_name} page you're looking for. You may want to return to the {studio_name} Dashboard and try again. If you are still having problems accessing things, please feel free to contact support')}</p>
     % elif error == '500':
       <h1>${_("The Server Encountered an Error")}</h1>
-      <p class="description">${Text(_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to {link_start}contact {studio_name} support{link_end} for further help.")).format(
-          studio_name=settings.STUDIO_SHORT_NAME,
-          link_start=HTML(help_link_start),
-          link_end=HTML(help_link_end),
-        )}</p>
+      <p class="description">${_("We're sorry. There was a problem with the server while trying to process your last request. You may want to return to the {studio_name} Dashboard or try this request again. If you are still having problems accessing things, please feel free to contact {studio_name} support for further help.").format(studio_name=settings.STUDIO_SHORT_NAME )}</p>
     % endif
     <a href="/" class="back-button">${_("Back to dashboard")}</a>
   </article>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -1,0 +1,115 @@
+<%inherit file="base.html" />
+<%def name="online_help_token()"><% return "register" %></%def>
+<%!
+from django.utils.translation import ugettext as _
+from django.core.urlresolvers import reverse
+%>
+
+<%block name="title">${_("Sign Up")}</%block>
+<%block name="bodyclass">not-signedin view-signup</%block>
+
+<%block name="content">
+
+<div class="wrapper-content wrapper">
+  <section class="content">
+    <header>
+      <h1 class="title title-1">${_("Sign Up for {studio_name}").format(studio_name=settings.STUDIO_NAME)}</h1>
+      <a href="${reverse('login')}" class="action action-signin">${_("Already have a {studio_name} Account? Sign in").format(studio_name=settings.STUDIO_SHORT_NAME)}</a>
+    </header>
+
+    <p class="introduction">${_("Ready to start creating online courses? Sign up below and start creating your first {platform_name} course today.").format(platform_name=settings.PLATFORM_NAME)}</p>
+
+    <article class="content-primary" role="main">
+      <form id="register_form" method="post">
+        <div id="register_error" name="register_error" class="message message-status message-status error">
+        </div>
+
+        <fieldset>
+          <legend class="sr">${_("Required Information to Sign Up for {studio_name}").format(studio_name=settings.STUDIO_NAME)}</legend>
+
+          <ol class="list-input">
+            <li class="field text required" id="field-email">
+              <label for="email">${_("E-mail")}</label>
+              ## Translators: This is the placeholder text for a field that requests an email address.
+              <input id="email" type="email" name="email" placeholder="${_("example: username@domain.com")}" />
+            </li>
+
+            <li class="field text required" id="field-name">
+              <label for="name">${_("Full Name")}</label>
+              ## Translators: This is the placeholder text for a field that requests the user's full name.
+              <input id="name" type="text" name="name" placeholder="${_("example: Jane Doe")}" />
+            </li>
+
+            <li class="field text required" id="field-username">
+              <label for="username">${_("Public Username")}</label>
+              ## Translators: This is the placeholder text for a field that asks the user to pick a username
+              <input id="username" type="text" name="username" placeholder="${_("example: JaneDoe")}" />
+              <span class="tip tip-stacked">${_("This will be used in public discussions with your courses and in our edX101 support forums")}</span>
+            </li>
+
+            <li class="field text required" id="field-password">
+              <label for="password">${_("Password")}</label>
+              <input id="password" type="password" name="password" />
+            </li>
+
+            <li class="field-group">
+              <div class="field text" id="field-location">
+                <label for="location">${_("Your Location")}</label>
+                <input class="short" id="location" type="text" name="location" />
+              </div>
+
+              <div class="field text" id="field-language">
+                <label for="language">${_("Preferred Language")}</label>
+                <input class="short" id="language" type="text" name="language" />
+              </div>
+            </li>
+
+            <li class="field checkbox required" id="field-tos">
+              <input id="tos" name="terms_of_service" type="checkbox" value="true" />
+              <label for="tos">
+                ${_("I agree to the {a_start} Terms of Service {a_end}").format(a_start='<a data-rel="edx.org" href="{}">'.format(marketing_link('TOS')), a_end="</a>")}
+              </label>
+            </li>
+          </ol>
+        </fieldset>
+
+        <div class="form-actions">
+          <button type="submit" id="submit" name="submit" class="action action-primary">${_("Create My Account &amp; Start Authoring Courses")}</button>
+        </div>
+
+        <!-- no honor code for CMS, but need it because we're using the lms student object -->
+        <input name="honor_code" type="checkbox" value="true" checked="true" hidden="true">
+      </form>
+    </article>
+
+    <aside class="content-supplementary" role="complementary">
+      <h2 class="sr">${_("Common {studio_name} Questions").format(studio_name=settings.STUDIO_SHORT_NAME)}</h2>
+
+      <div class="bit">
+        <h3 class="title-3">${_("Who is {studio_name} for?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
+        <p>${_("{studio_name} is for anyone that wants to create online courses that leverage the global {platform_name} platform. Our users are often faculty members, teaching assistants and course staff, and members of instructional technology groups.").format(
+          studio_name=settings.STUDIO_SHORT_NAME, platform_name=settings.PLATFORM_NAME,
+        )}</p>
+      </div>
+
+      <div class="bit">
+        <h3 class="title-3">${_("How technically savvy do I need to be to create courses in {studio_name}?").format(studio_name=settings.STUDIO_SHORT_NAME)}</h3>
+        <p>${_("{studio_name} is designed to be easy to use by almost anyone familiar with common web-based authoring environments (Wordpress, Moodle, etc.). No programming knowledge is required, but for some of the more advanced features, a technical background would be helpful. As always, we are here to help, so don't hesitate to dive right in.").format(
+          studio_name=settings.STUDIO_SHORT_NAME,
+        )}</p>
+      </div>
+
+      <div class="bit">
+        <h3 class="title-3">${_("I've never authored a course online before. Is there help?")}</h3>
+        <p>${_("Absolutely. We have created an online course, edX101, that describes some best practices: from filming video, creating exercises, to the basics of running an online course. Additionally, we're always here to help, just drop us a note.")}</p>
+      </div>
+    </aside>
+  </section>
+</div>
+</%block>
+
+<%block name="requirejs">
+    require(["js/factories/register"], function (RegisterFactory) {
+        RegisterFactory();
+    });
+</%block>

--- a/cms/templates/register.html
+++ b/cms/templates/register.html
@@ -65,10 +65,8 @@ from django.core.urlresolvers import reverse
             </li>
 
             <li class="field checkbox required" id="field-tos">
-              <input id="tos" name="terms_of_service" type="checkbox" value="true" />
-              <label for="tos">
-                ${_("I agree to the {a_start} Terms of Service {a_end}").format(a_start='<a data-rel="edx.org" href="{}">'.format(marketing_link('TOS')), a_end="</a>")}
-              </label>
+              <input id="tos" name="terms_of_service" type="checkbox" value="true" />              
+			  I agree to the <a href="http://openedx.microsoft.com/tos" target="_blank">Terms of Service </a>
             </li>
           </ol>
         </fieldset>


### PR DESCRIPTION
We synced to upstream open-release/eucalyptus.3 branch in edX-platform oxa/master.euc branch.
Stanford Theming was not allowing CMS theming. We are using comprehensive theming now. Comprehensive theming allows CMS changes as well. Before we did these changes in platform code. Now we are making these changes in CMS theming and platform change is not required anymore. 

CMS Terms of Service link, and 404, 500, error pages customized.