### PR TITLE
AAD Auto-Register on mytraining site

### DIFF
--- a/mytraining/lms/templates/register-form.html
+++ b/mytraining/lms/templates/register-form.html
@@ -243,7 +243,7 @@ from student.models import UserProfile
 
       % if has_extauth_info is UNDEFINED or ask_for_tos :
       <div class="field required checkbox" id="field-tos">
-        <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" />
+        <input id="tos-yes" type="checkbox" name="terms_of_service" value="true" required aria-required="true" checked />
         <label for="tos-yes">${_('I agree to the {link_start}Terms of Service{link_end}').format(
           link_start='<a href="{url}" class="new-vp" tabindex="-1">'.format(url=marketing_link('TOS')),
           link_end='</a>')}</label>
@@ -254,7 +254,7 @@ from student.models import UserProfile
       ## check if we have an Honor Code link in our marketing map
       % if marketing_link('HONOR') and marketing_link('HONOR') != '#':
       <div class="field ${settings.REGISTRATION_EXTRA_FIELDS['honor_code']} checkbox" id="field-honorcode">
-        <input id="honorcode-yes" type="checkbox" name="honor_code" value="true" />
+        <input id="honorcode-yes" type="checkbox" name="honor_code" value="true" checked/>
         <%
   		  # The honor_code link is updated as to go our Disclosure Notice anchor on the Terms Of Service page.
           honor_code_path = marketing_link('DN')

--- a/mytraining/lms/templates/register.html
+++ b/mytraining/lms/templates/register.html
@@ -84,12 +84,44 @@ import calendar
       });
     })(this);
 
+    // Handles third party auth with AAD and user account creation
+    // All programmatically so the user can be directed to
+    // mytraining.microsoft.com/register and their account will be
+    // auto created with "one-click" sign on from Infopedia.
     (function() {
+        // oa2-azuread-oauth2 will always be the provider_id for aad in ficus.
+        // So it is safe to select the button this way.
+        // provider_id is always backend_name (azuerad-oauth2) with oa2- prefixed
         aadButton = $('.button-oa2-azuread-oauth2.register-oa2-azuread-oauth2')[0]
+
+        // This aadButton is shown if the user doesn't have a session
+        // and is hidden if the button has been clicked and the user
+        // has returned from AAD authentication
         if (aadButton) {
-            aadButton.click()
+            // First page load (no session) so click the aadButton
+            aadButton.click();
+        } else {
+            // aadButton is hidden because we're back from
+            // AAD Authentication so we check if our form
+            // has all the required values filled out
+            // (meaning we had a successful response from AAD)
+            // If this is the case we submit the form.
+            if (requiredInputsHaveValues()) {
+                $('#register-form').submit();
+            }
         }
     })(this);
+    
+    // Returns true if all required inputs have values
+    function requiredInputsHaveValues() {
+        requiredInputs = $('input,textarea,select,checkbox').filter('[required]:visible')
+        for (var i = 0; i < requiredInputs.length; i++) {
+            if (!requiredInputs[i].value) {
+                return;
+            }
+        }
+        return true;
+    }
 
     function thirdPartySignin(event, url) {
       event.preventDefault();

--- a/mytraining/lms/templates/register.html
+++ b/mytraining/lms/templates/register.html
@@ -84,6 +84,13 @@ import calendar
       });
     })(this);
 
+    (function() {
+        aadButton = $('.button-oa2-azuread-oauth2.register-oa2-azuread-oauth2')[0]
+        if (aadButton) {
+            aadButton.click()
+        }
+    })(this);
+
     function thirdPartySignin(event, url) {
       event.preventDefault();
       window.location.href = url;

--- a/mytraining/lms/templates/register.html
+++ b/mytraining/lms/templates/register.html
@@ -89,11 +89,16 @@ import calendar
     // mytraining.microsoft.com/register and their account will be
     // auto created with "one-click" sign on from Infopedia.
     (function() {
-        // oa2-azuread-oauth2 will always be the provider_id for aad in ficus.
-        // So it is safe to select the button this way.
-        // provider_id is always backend_name (azuerad-oauth2) with oa2- prefixed
-        aadButton = $('.button-oa2-azuread-oauth2.register-oa2-azuread-oauth2')[0]
 
+        var oauth2Buttons = $('div.form-actions.form-third-party-auth > button');
+        var aadButton;
+
+        // Gets the first Oauth2 Sign up button in the third-party-auth div.
+        // On mytraining.microsoft.com, there will only ever be one and
+        // it will be the aadButton
+        if (oauth2Buttons && oauth2Buttons[0]) {
+            aadButton = oauth2Buttons[0]
+        }
         // This aadButton is shown if the user doesn't have a session
         // and is hidden if the button has been clicked and the user
         // has returned from AAD authentication
@@ -111,8 +116,7 @@ import calendar
             }
         }
     })(this);
-    
-    // Returns true if all required inputs have values
+
     function requiredInputsHaveValues() {
         requiredInputs = $('input,textarea,select,checkbox').filter('[required]:visible')
         for (var i = 0; i < requiredInputs.length; i++) {


### PR DESCRIPTION
Defaults honor code and terms of service to checked.
Takes user through AAD Authentication flow from start to finish on loading mytraining.microsoft.com/register

Now safely selects the AAD Button in order to programmatically click it on page load.