### PR TITLE
Fixed enabling of submit button after errors for login and register 

### DIFF
--- a/comprehensive/lms/templates/login.html
+++ b/comprehensive/lms/templates/login.html
@@ -100,7 +100,7 @@ from third_party_auth import provider, pipeline
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Sign into My {platform_name} Account').format(platform_name=platform_name)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
       }
       else {

--- a/comprehensive/lms/templates/register.html
+++ b/comprehensive/lms/templates/register.html
@@ -96,7 +96,7 @@ import calendar
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Create My {platform_name} Account').format(platform_name=platform_name)}");
       }
       else {

--- a/courses/lms/templates/login.html
+++ b/courses/lms/templates/login.html
@@ -119,11 +119,13 @@ from third_party_auth import provider, pipeline
       var $submitButton = $('form .form-actions #submit');
 
       if(enable) {
+        console.log('ENABLING SUBMIT BUTTON AGAIN.')
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Sign into My {platform_name} Account').format(platform_name=platform_name)} <span class='orn-plus'>+</span> ${_('Access My Courses')}");
+        console.log('DISABLED:', $submitButton.attr('disabled'))
       }
       else {
         $submitButton.

--- a/courses/lms/templates/register.html
+++ b/courses/lms/templates/register.html
@@ -142,7 +142,7 @@ import calendar
         $submitButton.
           removeClass('is-disabled').
           attr('aria-disabled', false).
-          removeProp('disabled').
+          prop('disabled', false).
           html("${_('Create My {platform_name} Account').format(platform_name=platform_name)}");
       }
       else {


### PR DESCRIPTION
This correctly removes the disabled property from the submit button of login and register pages after errors on both sites.