### PR TITLE
Explore Courses in Course View

### DIFF
--- a/comprehensive/lms/templates/navigation.html
+++ b/comprehensive/lms/templates/navigation.html
@@ -148,7 +148,7 @@ site_status_msg = get_site_status_msg(course_id)
               <li class="item nav-global-05">
                 <a class="btn" href="/courses">${_("Explore Courses")}</a>
               </li>
-			% else:
+	    % else:
               % if course:
                 <li class="item nav-global-05">
                   <a class="btn" href="/courses">${_("Explore courses")}</a>

--- a/comprehensive/lms/templates/navigation.html
+++ b/comprehensive/lms/templates/navigation.html
@@ -144,16 +144,10 @@ site_status_msg = get_site_status_msg(course_id)
 
         <%block name="navigation_other_global_links">
           % if not settings.FEATURES['DISABLE_LOGIN_BUTTON']:
-            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY'):
+            % if settings.FEATURES.get('ENABLE_COURSE_DISCOVERY') or course:
               <li class="item nav-global-05">
                 <a class="btn" href="/courses">${_("Explore Courses")}</a>
-              </li>
-	    % else:
-              % if course:
-                <li class="item nav-global-05">
-                  <a class="btn" href="/courses">${_("Explore courses")}</a>
-                </li>
-              % endif
+	      </li>
             % endif
           % endif
         </%block>

--- a/comprehensive/lms/templates/navigation.html
+++ b/comprehensive/lms/templates/navigation.html
@@ -148,6 +148,12 @@ site_status_msg = get_site_status_msg(course_id)
               <li class="item nav-global-05">
                 <a class="btn" href="/courses">${_("Explore Courses")}</a>
               </li>
+			% else:
+              % if course:
+                <li class="item nav-global-05">
+                  <a class="btn" href="/courses">${_("Explore courses")}</a>
+                </li>
+              % endif
             % endif
           % endif
         </%block>


### PR DESCRIPTION
#### What's this PR do? Any additional context?
Allow the user to view all the courses even though he didn't sign in or Register
#### Where should the reviewer start?
Click on any course in the main page and now the use can see the Explore Course link to view all other courses
#### How can this be manually tested? (brief repro steps)
Before: There is no provision to able to view all the other course
After  : Now the user can able to see the Explore Course link
#### What are the relevant TFS items? (list id numbers)
User Story : 91635
#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [x] For large or complex change: schedule an in-person review session

[//]: # ( todo: Is there appropriate test coverage? )
[//]: # ( todo: Does this PR require a new Selenium test? )
[//]: # ( todo: Is there appropriate logging/monitoring included? )

#### Reminders BEFORE merging
1. Get at least two approvals
1. If you're merging into the development branch then "flatten" or "squash" commits
1. If merging from development into master then don't "flatten" or "squash" commits

#### Reminders AFTER merging
1. Delete the remote branch
1. Resolve relevant TFS items
1. (reverse merge) If you merged into master then check to see if there are any changes in master that can be merged down to the development branch (like hotfixes, etc)

[//]: # ( todo: If you merged into development branch then verify change in our "rolling deployment" environment. Then notify stakeholders interested in or involved with the change )


[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 3 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 4 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 5 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
