### PR TITLE
Hide user dropdown options during msa migration

### DIFF
--- a/comprehensive/lms/templates/user_dropdown.html
+++ b/comprehensive/lms/templates/user_dropdown.html
@@ -20,9 +20,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <span class="sr-only">${_("Dashboard for:")}</span>
             <%
             username = self.real_user.username
-            profile_image_url = get_profile_image_urls_for_user(self.real_user)['small']
             %>
-            <!--<img class="menu-image" src="${profile_image_url}" alt="">-->
             ${username}
         </a>
         <div role="group" aria-label="User menu" class="user-menu">
@@ -55,7 +53,9 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <div role="group" aria-label="User menu" class="user-menu">
                 <button class="dropdown" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
                 <ul class="dropdown-menu" aria-label="More Options" role="menu">
-                    ${navigation_dropdown_menu_links()}
+                    % if request.get_full_path() not in ['/account/link', '/account/link/confirm']:                        
+                        ${navigation_dropdown_menu_links()}
+                    % endif
                     <li class="item"><a href="${reverse('logout')}" role="menuitem" class="dropdown-menuitem">${_("Sign Out")}</a></li>
                 </ul>
             </div>

--- a/comprehensive/lms/templates/user_dropdown.html
+++ b/comprehensive/lms/templates/user_dropdown.html
@@ -53,7 +53,7 @@ from openedx.core.djangoapps.user_api.accounts.image_helpers import get_profile_
             <div role="group" aria-label="User menu" class="user-menu">
                 <button class="dropdown" aria-expanded="false"><span class="sr">${_("More options dropdown")}</span><span class="fa fa-sort-desc" aria-hidden="true"></span></button>
                 <ul class="dropdown-menu" aria-label="More Options" role="menu">
-                    % if request.get_full_path() not in ['/account/link', '/account/link/confirm']:                        
+                    % if request.path() not in ['/account/link', '/account/link/confirm']:                        
                         ${navigation_dropdown_menu_links()}
                     % endif
                     <li class="item"><a href="${reverse('logout')}" role="menuitem" class="dropdown-menuitem">${_("Sign Out")}</a></li>


### PR DESCRIPTION
#### What does this PR do? Please provide some context

Removes dashboard, profile, account links in user dropdown while the user is in progress with MSA migration.

#### What are the relevant TFS items? (list id numbers)

109340 and 109341

#### Definition of done:
- [ x] Title of the pull request is clear and informative
- [ ] This change has appropriate test coverage

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
