### PR TITLE
Hide user account add/delete from Sysadmin dashboard if third-party auth is enabled

### DIFF
--- a/comprehensive/lms/templates/sysadmin_dashboard.html
+++ b/comprehensive/lms/templates/sysadmin_dashboard.html
@@ -3,6 +3,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+import third_party_auth
 %>
 
 <%block name="headextra">
@@ -65,7 +66,7 @@ textarea {
 
     <form name="action" method="POST">
     <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
-
+    %if not third_party_auth.is_enabled():
 	<ul class="list-input">
 	  <li class="field text" style="padding-bottom: 1.2em">
 		<label for="student_uname">${_('Email or username')}</label>
@@ -90,6 +91,9 @@ textarea {
     </div>
 
 	<hr />
+	%else:
+	<br>
+	%endif
     <p>
       <button type="submit" name="action" value="download_users" style="width: 350px;">
 		${_('Download list of all users (csv file)')}

--- a/courses/lms/templates/sysadmin_dashboard.html
+++ b/courses/lms/templates/sysadmin_dashboard.html
@@ -3,6 +3,7 @@
 <%!
 from django.urls import reverse
 from django.utils.translation import ugettext as _
+import third_party_auth
 %>
 
 <%block name="headextra">
@@ -65,7 +66,7 @@ textarea {
 
     <form name="action" method="POST">
     <input type="hidden" name="csrfmiddlewaretoken" value="${ csrf_token }" />
-
+    %if not third_party_auth.is_enabled():
 	<ul class="list-input">
 	  <li class="field text" style="padding-bottom: 1.2em">
 		<label for="student_uname">${_('Email or username')}</label>
@@ -90,6 +91,9 @@ textarea {
     </div>
 
 	<hr />
+	%else:
+	<br>
+	%endif
     <p>
       <button type="submit" name="action" value="download_users" style="width: 350px;">
 		${_('Download list of all users (csv file)')}


### PR DESCRIPTION
#### What does this PR do? Please provide some context
Hides the user account add/delete feature from the Sysadmin dashboard if third-party auth is enabled.

#### Where should the reviewer start?
Either file

#### How can this be manually tested? (brief repro steps and corpnet-URL with change)
Deploy Hawthorn, login and select Sysadmin, verify that text entry fields and buttons to add/delete users are not present within User Management.

#### What are the relevant TFS items? (list id numbers)
Bug 801865

#### Definition of done:
- [ ] Title of the pull request is clear and informative
- [ ] Add pull request hyperlink to relevant TFS items
- [ ] For large or complex change: schedule an in-person review session
- [ ] This change has appropriate test coverage
- [ ] Get at least two approvals

#### Reminders DURING merge
1. If you're merging from a short-term (feature) branch into a long-term branch (like dev, release, or master) then "Squash and merge" to keep our history clean.
1. If merging from two longterm branches (like cherry picks from upstream, dev to release, etc) then "Create merge commit" to preserve individual commits.

[//]: # ( fyi: This content was heavily inspired by )
[//]: # ( 1 Our team's policies and processes )
[//]: # ( 2 https://github.com/sprintly/sprint.ly-culture/blob/master/pr-template.md )
[//]: # ( 3 The book "The Checklist Manifesto: How to Get Things Right" by Atul Gawande )
[//]: # ( 4 https://github.com/Azure/azure-event-hubs/blob/master/.github/PULL_REQUEST_TEMPLATE.md )
